### PR TITLE
frontend fixes

### DIFF
--- a/src/components/ResultImages2026.jsx
+++ b/src/components/ResultImages2026.jsx
@@ -51,7 +51,7 @@ const ResultImages2026 = () => {
     <div className="min-h-screen bg-gradient-to-br from-[#1e1e2f] to-[#2c2c3e] py-12 px-4">
       <div className="max-w-5xl mx-auto">
         <h1 className="text-xl md:text-4xl font-bold text-center text-blue-100 mb-4 font-alfa tracking-wide">
-          ------ Executives Selected ------
+          ------ Head Selected 2026-27 ------
         </h1>
         <p className="text-center text-gray-300 mb-10 font-nunito">
           Congratulations to all

--- a/src/components/notifications/NotificationsButton.jsx
+++ b/src/components/notifications/NotificationsButton.jsx
@@ -583,9 +583,9 @@ export default function NotificationsButton({
                                             </p>
                                           )
                                         ) : (
-                                          n.metadata?.senderRole && (
+                                          (n.senderName || n.metadata?.senderRole) && (
                                             <p className={`text-[10px] font-medium ${color === "pink" ? "text-pink-300" : "text-green-400"}`}>
-                                              from {n.metadata.senderRole}
+                                              from {n.senderName || n.metadata?.senderRole}
                                             </p>
                                           )
                                         )}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -425,7 +425,7 @@ const journeyPhotos = [
                       sm:gap-3 sm:px-7 sm:py-3 sm:text-sm
                     "
                   >
-                    2025 Heads Result
+                    2025 Recruitment Results
 
                     <Trophy className="h-4 w-4 transition group-hover:rotate-6 group-hover:scale-110" />
                   </button>

--- a/src/pages/ResultPage2026.jsx
+++ b/src/pages/ResultPage2026.jsx
@@ -56,18 +56,6 @@ const ResultPage2026 = () => {
           {/* Description */}
           <p className="text-base text-[#aaa] text-center">
             Checkout here....
-            <a
-              className="text-blue-400 text-base flex items-center justify-center gap-2 mt-2"
-              href="https://www.instagram.com/stories/gfg_bvcoe/?hl=en"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Click here to see results on
-              <Instagram
-                className="text-green-500 hover:text-blue-400 transition-colors"
-                size={16}
-              />
-            </a>
           </p>
 
           <p className="text-base text-[#aaa] mb-6 text-center mt-2">


### PR DESCRIPTION
### Changes made:
- **Home Page**: Renamed the `2025 Heads Result` button to `2025 Recruitment Results`.
- **2026 Results Page**: 
  - Removed the Instagram redirect link and text
  - Renamed the `Executives Selected` heading to `Head Selected 2026-27`.
- **Notifications**: Updated the notification dropdown to display the actual `senderName` instead of just the user's position 
