### PR TITLE
feat: restrict blog edit to author and delete to authorized roles

### DIFF
--- a/server/controllers/blogController.js
+++ b/server/controllers/blogController.js
@@ -259,3 +259,174 @@ exports.getPostBySlug = async (req, res) => {
     });
   }
 };
+
+exports.editPost = async (req, res) => {
+  try {
+    const { postId } = req.params;
+    const { title, content, summary, coverImage, category, tags } = req.body;
+
+    const post = await Post.findById(postId);
+    if (!post) {
+      return res.status(404).json({
+        success: false,
+        message: "Blog post not found.",
+      });
+    }
+
+    // Only the author of the post can edit it
+    if (post.author.toString() !== req.user.id) {
+      return res.status(403).json({
+        success: false,
+        message: "Access denied. Only the author of the post can edit it.",
+      });
+    }
+
+    // Validation (type checks)
+    if (title && typeof title !== "string") {
+      return res.status(400).json({
+        success: false,
+        message: "Title must be a string.",
+      });
+    }
+    if (content && typeof content !== "string") {
+      return res.status(400).json({
+        success: false,
+        message: "Content must be a string.",
+      });
+    }
+    if (summary && typeof summary !== "string") {
+      return res.status(400).json({
+        success: false,
+        message: "Summary must be a string.",
+      });
+    }
+    if (category && typeof category !== "string") {
+      return res.status(400).json({
+        success: false,
+        message: "Category must be a string.",
+      });
+    }
+    if (tags && !Array.isArray(tags)) {
+      return res.status(400).json({
+        success: false,
+        message: "Tags must be an array of strings.",
+      });
+    }
+
+    // Moderation and Audit checks
+    const checkTitle = title || post.title;
+    const checkContent = content || post.content;
+    const checkSummary = summary || post.summary || "";
+
+    if (containsProfanity(checkTitle) || containsProfanity(checkContent) || containsProfanity(checkSummary)) {
+      return res.status(400).json({
+        success: false,
+        message: "Update blocked: Content contains inappropriate or vulgar language.",
+      });
+    }
+
+    // Apply updates
+    if (title && title !== post.title) {
+      post.title = title;
+      post.slug = await generateUniqueSlug(title);
+    }
+
+    if (content) {
+      post.content = sanitizeHtml(content);
+      post.qualityAudit = calculateQualityAudit(post.content);
+    }
+
+    if (summary !== undefined) {
+      post.summary = summary;
+    }
+
+    if (category !== undefined) {
+      post.category = category;
+    }
+
+    if (tags !== undefined) {
+      post.tags = tags;
+    }
+
+    // Handle cover image upload or URL string
+    if (req.files && req.files.coverImage) {
+      const uploadResult = await imageUpload(req.files.coverImage, "blogImages", 80);
+      post.coverImage = uploadResult.secure_url;
+    } else if (coverImage !== undefined) {
+      if (coverImage && typeof coverImage !== "string") {
+        return res.status(400).json({
+          success: false,
+          message: "Cover image must be a string URL.",
+        });
+      }
+      post.coverImage = coverImage;
+    }
+
+    // Reset status to pending_approval on edit
+    post.status = "pending_approval";
+    post.feedback = "";
+
+    await post.save();
+
+    return res.status(200).json({
+      success: true,
+      message: "Post updated successfully and is pending approval.",
+      post,
+    });
+  } catch (error) {
+    console.error("editPost error:", error);
+    return res.status(500).json({
+      success: false,
+      message: "Failed to edit post.",
+      error: error.message,
+    });
+  }
+};
+
+exports.deletePost = async (req, res) => {
+  try {
+    const { postId } = req.params;
+
+    const post = await Post.findById(postId);
+    if (!post) {
+      return res.status(404).json({
+        success: false,
+        message: "Blog post not found.",
+      });
+    }
+
+    const user = await User.findById(req.user.id);
+    if (!user) {
+      return res.status(404).json({
+        success: false,
+        message: "User not found.",
+      });
+    }
+
+    // Delete access belongs to the author of the post, or users with role lead/head/ADMIN
+    const isAuthor = post.author.toString() === req.user.id;
+    const isLeadOrHeadOrAdmin = user.role === "lead" || user.role === "head" || user.accountType === "ADMIN";
+
+    if (!isAuthor && !isLeadOrHeadOrAdmin) {
+      return res.status(403).json({
+        success: false,
+        message: "Access denied. You do not have permission to delete this post.",
+      });
+    }
+
+    await Post.findByIdAndDelete(postId);
+
+    return res.status(200).json({
+      success: true,
+      message: "Blog post deleted successfully.",
+    });
+  } catch (error) {
+    console.error("deletePost error:", error);
+    return res.status(500).json({
+      success: false,
+      message: "Failed to delete post.",
+      error: error.message,
+    });
+  }
+};
+

--- a/server/routes/blogRoute.js
+++ b/server/routes/blogRoute.js
@@ -6,6 +6,8 @@ const {
   approvePost,
   getPublicPosts,
   getPostBySlug,
+  editPost,
+  deletePost,
 } = require("../controllers/blogController");
 
 const router = express.Router();
@@ -25,9 +27,11 @@ router.get("/public", getPublicPosts);
 // Public route: fetch specific blog post details by its SEO slug (public)
 router.get("/post/:slug", getPostBySlug);
 
+// Author edits their own post (requires authentication)
+router.put("/edit/:postId", auth, editPost);
 
-
-
+// Author, Leads, Heads or Admins can delete a post (requires authentication)
+router.delete("/delete/:postId", auth, deletePost);
 
 module.exports = router;
 


### PR DESCRIPTION
### Summary
This PR adds authorization restrictions for editing and deleting blog posts.

### Changes
- Added `PUT /edit/:postId` route and `editPost` controller:
  - Restricted edits to the post's author.
  - Reset post status to `pending_approval` on edit.
  - Added profanity checks and HTML sanitization.
- Added `DELETE /delete/:postId` route and `deletePost` controller:
  - Allowed deletion only by the post author, Leads, Heads, or Admins.